### PR TITLE
Real line representing in braille 

### DIFF
--- a/addon/appModules/devenv/overlays.py
+++ b/addon/appModules/devenv/overlays.py
@@ -17,7 +17,6 @@ import braille
 import api
 from logHandler import log
 import UIAHandler
-import UIAUtils
 from NVDAObjects import NVDAObject
 from NVDAObjects.UIA import Toast_win8 as Toast
 from NVDAObjects.UIA import UIA, UIATextInfo, WpfTextView


### PR DESCRIPTION
## Issue description:
The Visual Studio editor component does not honor UIA TextRange.getText.
Instead of reporting the "real" line, it adds some chars before, that includes the line number and a space.
This causes two issues for braille users:

1. When pressing cursor routing keys, the cursor will be placed n characters before the position you expecting to be (3 if a 10+ line is selected, 4 if  you are in a 100+ line etc.);

2. When the caret is located on the first character of the line, you'll read the number of lines twice: the first time because the UIA Object reports it as a starting of the line, and a second time because it reports it as the current character under the caret.

## Proposed approach
If a TextRange is returned, that has more than two chars, we parse it using a regex to remove the extra line numbers. To alleviate drawbacks, this override is activated only if a braille display is active.

## Drawbacks
* Screen reader does not honor information from the application, information changed;
* Line number is not reported from the screen reader when a braille display is connected.